### PR TITLE
Use a standard HTML structure for wallet payments display

### DIFF
--- a/backend/app/views/spree/admin/users/wallet_payments/_source.html.erb
+++ b/backend/app/views/spree/admin/users/wallet_payments/_source.html.erb
@@ -1,17 +1,19 @@
 <% if source.is_a?(Spree::CreditCard) %>
-  <span class="cc-type">
-    <% unless (cc_type = source.cc_type).blank? %>
-      <%= image_tag "credit_cards/icons/#{cc_type}.png" %>
-    <% end %>
-    <% if source.last_digits %>
-      <%= source.display_number %>
-    <% end %>
-  </span> -
-  <span class="full-name"><%= source.name %></span>
+  <dl>
+    <dt><%= t('spree.name_on_card') %>:</dt>
+    <dd><%= source.name %></dd>
 
-  <% if source.month && source.year %>
-    <span class="pill pill-<%= source.expired? ? 'expired' : 'ready' %>">
-      <%= source.month %>/<%= source.year %>
-    </span>
-  <% end %>
+    <dt><%= Spree::CreditCard.human_attribute_name(:cc_type) %>:</dt>
+    <dd><%= source.cc_type %></dd>
+
+    <dt><%= Spree::CreditCard.human_attribute_name(:number) %>:</dt>
+    <dd><%= source.display_number %></dd>
+
+    <dt><%= Spree::CreditCard.human_attribute_name(:expiration) %>:</dt>
+    <dd>
+      <span class="pill pill-<%= source.expired? ? 'expired' : 'ready' %>">
+        <%= source.month %>/<%= source.year %>
+      </span>
+    </dd>
+  </dl>
 <% end %>


### PR DESCRIPTION
**Description**

The previous implementation was wrong, since if the store is
using a custom frontend, we don't have the credit card images
available, which results in missing assets.

The current implementation reflects what we have in the payment
details in the backend already.

This is what we already have at http://localhost:3000/admin/orders/R776553937/payments/6

<img width="1545" alt="Screenshot 2020-05-06 at 10 41 20" src="https://user-images.githubusercontent.com/167946/81156384-2f4a2780-8f86-11ea-8dc3-687b9b88bcff.png">

This is the result in the Wallet

<img width="1420" alt="Screenshot 2020-05-06 at 10 42 17" src="https://user-images.githubusercontent.com/167946/81156469-44bf5180-8f86-11ea-8b27-5b9e5119e01e.png">

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
