### PR TITLE
set canceled_at when canceling an order with cancel

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -591,10 +591,9 @@ module Spree
     def canceled_by(user)
       transaction do
         cancel!
-        update_columns(
-          canceler_id: user.id,
-          canceled_at: Time.current
-        )
+        # rubocop:disable Rails/SkipsModelValidations
+        update_column(:canceler_id, user.id)
+        # rubocop:enable Rails/SkipsModelValidations
       end
     end
 
@@ -878,6 +877,9 @@ module Spree
       payments.store_credits.pending.each(&:void_transaction!)
 
       send_cancel_email
+      # rubocop:disable Rails/SkipsModelValidations
+      update_column(:canceled_at, Time.current)
+      # rubocop:enable Rails/SkipsModelValidations
       recalculate
     end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -107,6 +107,11 @@ RSpec.describe Spree::Order, type: :model do
         expect(order).to be_canceled
       end
 
+      it 'should save canceled_at' do
+        subject
+        expect(order.reload.canceled_at).to_not be_nil
+      end
+
       it "places the order into the canceled scope" do
         expect{ subject }.to change{ Spree::Order.canceled.include?(order) }.from(false).to(true)
       end
@@ -150,11 +155,6 @@ RSpec.describe Spree::Order, type: :model do
     it 'should save canceler_id' do
       subject
       expect(order.reload.canceler_id).to eq(admin_user.id)
-    end
-
-    it 'should save canceled_at' do
-      subject
-      expect(order.reload.canceled_at).to_not be_nil
     end
 
     it 'should have canceler' do


### PR DESCRIPTION
**Description**
Set `canceled_at` field on the order when calling `order.cancel` or `order.cancel!` 
  Ref issue #3608

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [X] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
