### PR TITLE
Fix TaxCategory default not showing up in admin

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -96,6 +96,7 @@ module Spree
 
       def load_data
         @tax_categories = Spree::TaxCategory.order(:name)
+        @default_tax_category = @tax_categories.detect(&:is_default)
         @shipping_categories = Spree::ShippingCategory.order(:name)
       end
 

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -146,8 +146,8 @@
       <div data-hook="admin_product_form_tax_category">
         <%= f.field_container :tax_category do %>
           <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
-          <%= f.field_hint :tax_category %>
-          <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { include_blank: t('spree.match_choices.none') }, { class: 'custom-select' }) %>
+          <%= f.field_hint :tax_category, default_tax_category: @default_tax_category&.name %>
+          <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { include_blank: t('spree.match_choices.none'), selected: @default_tax_category&.id }, { class: 'custom-select' }) %>
           <%= f.error_message_on :tax_category %>
         <% end %>
       </div>

--- a/backend/config/initializers/form_builder.rb
+++ b/backend/config/initializers/form_builder.rb
@@ -13,8 +13,8 @@ class ActionView::Helpers::FormBuilder
   end
 
   def field_hint(method, options = {})
-    title = options[:title] || @object.class.human_attribute_name(method)
-    text = options[:text] || I18n.t(method, scope: [:spree, :hints, @object.class.model_name.i18n_key])
+    title = options.delete(:title) || @object.class.human_attribute_name(method)
+    text = options.delete(:text) || I18n.t(method, scope: [:spree, :hints, @object.class.model_name.i18n_key], **options)
     @template.admin_hint(title, text)
   end
 end

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -156,6 +156,7 @@ describe "Products", type: :feature do
     context "creating a new product" do
       before(:each) do
         @shipping_category = create(:shipping_category)
+        @tax_category = create(:tax_category, name: 'Alcohol taxes', is_default: true)
         click_nav "Products"
         click_on "New Product"
       end
@@ -238,6 +239,10 @@ describe "Products", type: :feature do
         expect(page).to have_content("successfully created!")
         click_button "Update"
         expect(page).to have_content("successfully updated!")
+      end
+
+      it "should show default tax category" do
+        expect(page).to have_select('product_tax_category_id', selected: 'Alcohol taxes')
       end
     end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1403,7 +1403,7 @@ en:
         shipping_category: 'This determines what kind of shipping this product requires.<br/>
           Default: Default'
         tax_category: 'This determines what kind of taxation is applied to this product.<br/>
-          Default: None'
+          Default: %{default_tax_category}'
       spree/promotion:
         expires_at: This determines when the promotion expires. <br/> If no value
           is specified, the promotion will never expire.


### PR DESCRIPTION
**Description**
When visiting New products page, Spree::TaxCategory with _is_default_ set to true is not being shown as the first selected option in the tax category select box. Additionally, the hint of the select box is saying that the default is None despite having other Spree::TaxCategory as default. This PR aims to fix it.

**Without change**
![tax_category_failed](https://user-images.githubusercontent.com/1108998/93101206-617c3c00-f680-11ea-9528-c3785e11f303.png)

**With change**
![tax_category_success](https://user-images.githubusercontent.com/1108998/93101221-6640f000-f680-11ea-9ce9-6dbcac4152c5.png)

**Checklist:**
- [*] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [*] I have added a detailed description into each commit message
- [*] I have updated Guides and README accordingly to this change (if needed)
- [*] I have added tests to cover this change (if needed)
- [*] I have attached screenshots to this PR for visual changes (if needed)
