### PR TITLE
Remove ability to void invalid payments

### DIFF
--- a/core/app/models/spree/payment_source.rb
+++ b/core/app/models/spree/payment_source.rb
@@ -23,9 +23,9 @@ module Spree
     end
 
     # @param payment [Spree::Payment] the payment we want to know if can be voided
-    # @return [Boolean] true when the payment is not failed or voided
+    # @return [Boolean] true when the payment is not failed, voided or invalid
     def can_void?(payment)
-      !payment.failed? && !payment.void?
+      payment.can_void?
     end
 
     # Indicates whether its possible to credit the payment.  Note that most

--- a/core/spec/support/concerns/payment_source.rb
+++ b/core/spec/support/concerns/payment_source.rb
@@ -26,9 +26,10 @@ RSpec.shared_examples "a payment source" do
   end
 
   describe "#can_void?" do
-    it "should be true if payment is not void" do
-      payment = mock_model(Spree::Payment, failed?: false, void?: false)
-      expect(payment_source.can_void?(payment)).to be true
+    it "should call payment#can_void?" do
+      payment = mock_model(Spree::Payment, can_void?: true)
+      expect(payment).to receive(:can_void?)
+      payment_source.can_void?(payment)
     end
   end
 


### PR DESCRIPTION
Voiding invalid payments will result in an error due to the lack of
response_code. Additionally, this transition is not allowed in the
payment state machine.