### PR TITLE
Prevent error on payment details admin page when store credit category is nil

### DIFF
--- a/backend/app/views/spree/admin/payments/source_views/_store_credit.html.erb
+++ b/backend/app/views/spree/admin/payments/source_views/_store_credit.html.erb
@@ -5,7 +5,7 @@
     <div class="col-4">
       <dl>
         <dt><%= Spree::StoreCreditCategory.model_name.human %>:</dt>
-        <dd><%= payment.source.category.name%></dd>
+        <dd><%= payment.source.category&.name%></dd>
 
         <dt><%= Spree::StoreCredit.human_attribute_name(:memo) %>:</dt>
         <dd><%= payment.source.memo %></dd>


### PR DESCRIPTION
Adds safe navigation operator when displaying category name to avoid errors when category was deleted.