### PR TITLE
Fix CSRF vulnerability that allowed (un)finalizing adjustments

### DIFF
--- a/backend/app/views/spree/admin/adjustments/_adjustments_table.html.erb
+++ b/backend/app/views/spree/admin/adjustments/_adjustments_table.html.erb
@@ -13,12 +13,12 @@
     <tr data-hook="adjustment_buttons">
       <td class="align-right" colspan="2" style="width: 50%">
         <% if can? :update, Spree::Adjustment %>
-          <%= button_to t('spree.unfinalize_all_adjustments'), adjustments_unfinalize_admin_order_path(@order), method: :get %>
+          <%= button_to t('spree.unfinalize_all_adjustments'), adjustments_unfinalize_admin_order_path(@order), method: :put %>
         <% end %>
       </td>
       <td colspan="2" style="width: 50%">
         <% if can? :update, Spree::Adjustment %>
-          <%= button_to t('spree.finalize_all_adjustments'), adjustments_finalize_admin_order_path(@order), method: :get %>
+          <%= button_to t('spree.finalize_all_adjustments'), adjustments_finalize_admin_order_path(@order), method: :put %>
         <% end %>
       </td>
       <td class='actions'>&nbsp;</td>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -77,8 +77,8 @@ Spree::Core::Engine.routes.draw do
         get :confirm
         put :complete
         post :resend
-        get "/adjustments/unfinalize", to: "orders#unfinalize_adjustments"
-        get "/adjustments/finalize", to: "orders#finalize_adjustments"
+        put "/adjustments/unfinalize", to: "orders#unfinalize_adjustments"
+        put "/adjustments/finalize", to: "orders#finalize_adjustments"
         put :approve
         put :cancel
         put :resume
@@ -91,7 +91,7 @@ Spree::Core::Engine.routes.draw do
         end
       end
 
-      resources :adjustments
+      resources :adjustments, except: [:show]
       resources :return_authorizations do
         member do
           put :fire

--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -108,6 +108,44 @@ describe "Adjustments", type: :feature do
         expect(page).to have_content("Amount is not a number")
       end
     end
+
+    context "admin bulk editing adjustments" do
+      it "allows finalizing all the adjustments" do
+        order.all_adjustments.each(&:unfinalize!)
+
+        click_button "Finalize All Adjustments"
+
+        expect(order.reload.adjustments.all?(&:finalized?)).to be(true)
+      end
+
+      it "allows unfinalizing all the adjustments" do
+        order.all_adjustments.each(&:finalize!)
+
+        click_button "Unfinalize All Adjustments"
+
+        expect(order.reload.adjustments.any?(&:finalized?)).to be(false)
+      end
+
+      it "can't finalize via a GET request" do
+        order.all_adjustments.each(&:unfinalize!)
+
+        expect {
+          visit "/admin/orders/#{order.number}/adjustments/finalize"
+        }.to raise_error(ActionController::RoutingError)
+
+        expect(order.reload.adjustments.any?(&:finalized?)).to be(false)
+      end
+
+      it "can't unfinalize via a GET request" do
+        order.all_adjustments.each(&:finalize!)
+
+        expect {
+          visit "/admin/orders/#{order.number}/adjustments/unfinalize"
+        }.to raise_error(ActionController::RoutingError)
+
+        expect(order.reload.adjustments.all?(&:finalized?)).to be(true)
+      end
+    end
   end
 
   context "deleting an adjustment" do


### PR DESCRIPTION
solidus `v2.11.16` cherrypick  `5cd33b13c86f1a7089037d4ca2df9c3f10942ba6` 

https://github.com/solidusio/solidus/commit/de796a2e0be7f154cae48b46e267501559d9716c

Severity `Low`
------------------------
As the routes to finalize/unfinalize adjustments were `GET` requests, an
attacker could run them without the user's realization.

We change both routes to be `PUT` requests. We're adding missing tests
for the feature and regression tests for the CSRF vulnerability. We're
explicitly excluding `:show` from the adjustments' routes so that the
meaningful exception `ActionController::RoutingError` is raised when
trying to access via `GET`.

See
[GHSA-8639-qx56-r428](https://github.com/solidusio/solidus/security/advisories/GHSA-8639-qx56-r428)
for details and instructions to reproduce.